### PR TITLE
Improve copyright loading with paging and simplify preprocessing steps 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+
+# secrets
+.restconfig.json
+
+# IDE
+.vscode
+
+# generated files
+/__pycache__
+report*.txt
+report*.html
+report*.json
+profiler.txt

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2022 Matthew Brady
+Copyright (c) 2022 Commend International, autor: Benjamin Moser
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Readme.md
+++ b/Readme.md
@@ -56,6 +56,11 @@ optional arguments:
 -  -nf, --not_filtered - Don't perform any filtering
 -  -sr, --show_rejected - Show all lines that were processed for copyright but were  ultimately rejected
 -  -o \<filename\>, --output-text \<filename\>  - Output report as text
--  -oh \<filename\>, --output-html \<filename\> -  Output report as html
+-  -oh \<filename\>, --output-html \<filename\> - Output report as html
+-  -l 2 , --max_lines 2, - Maximum processed copyright lines: default 2
+-  -c all, --code_languages all - Specify which code fragments should be eliminated: csharp,cpp,java,js,shell,xml,sql
 
+TODO:
+Move postprocessing steps like copyright match filtering and duplicates elimination to CopyrightProcessor.
+Read code and license fragments from files which contain regular expressions and string replace patterns.
 

--- a/Readme.md
+++ b/Readme.md
@@ -60,7 +60,11 @@ optional arguments:
 -  -l 2 , --max_lines 2, - Maximum processed copyright lines: default 2
 -  -c all, --code_languages all - Specify which code fragments should be eliminated: csharp,cpp,java,js,shell,xml,sql
 
-TODO:
-Move postprocessing steps like copyright match filtering and duplicates elimination to CopyrightProcessor.
-Read code and license fragments from files which contain regular expressions and string replace patterns.
+# TODO:
+* Move postprocessing steps like copyright match filtering and duplicates elimination to CopyrightProcessor.
+* Read code and license fragments from files which contain regular expressions and string replace patterns.
+
+# LIMITATIONS
+* Synchronous download of copyright and license information using hub.execute_get functions with >0.6s/call.
+
 

--- a/copyrightmanager.py
+++ b/copyrightmanager.py
@@ -1,9 +1,8 @@
 from blackduck.HubRestApi import HubInstance
-import regex
-import html2text
-import unicodedata, itertools, sys
 import logging
-
+import regex
+from copyrightprocessor import CopyrightProcessor
+    
 class CopyrightManager:
     """Manage copyrights for a BOM component"""
     component_name = ""
@@ -20,10 +19,29 @@ class CopyrightManager:
         self.load_copyrights()
 
     def load_copyrights(self):
-        url = self.hub.get_link(self.origin, "component-origin-copyrights")
-        url = url + "?limit=1000"
-        self.copyrights = self.hub.execute_get(url).json().get('items', [])
-        logging.debug("length {}".format(len(self.copyrights)))
+        limit = 1000
+        offset = 0
+        self.copyrights = None
+
+        # do while loaded != 0
+        while True:
+            url = self.hub.get_link(self.origin, "component-origin-copyrights")
+            url = url + "?limit="+str(limit)+"&offset="+str(offset)
+            rsp = self.hub.execute_get(url).json().get('items', [])
+            if (len(rsp) == 0):
+                break
+
+            if (self.copyrights == None):
+                self.copyrights = rsp
+            else:
+                self.copyrights.extend(rsp)
+
+            logging.info("Total copyrights {}, currently loaded {}".format(len(self.copyrights), len(rsp)))
+
+            if (len(rsp) < limit):
+                break
+            else:
+                offset += len(rsp)
 
     def disable_all_copyrights(self, source='KB'):
         for copyright in self.copyrights:
@@ -52,113 +70,25 @@ class CopyrightManager:
     #     return
 
 
-
-
-
-    def remove_control_chars(self, s):
-        all_chars = (chr(i) for i in range(sys.maxunicode))
-        categories = {'Cc'}
-        control_chars = ''.join(map(chr, itertools.chain(range(0x00, 0x20), range(0x7f, 0xa0))))
-
-        control_char_regex = regex.compile('[%s]' % regex.escape(control_chars))
-
-        return control_char_regex.sub(' ', s)
-
-    def preprocess_copyrights(self):
+    def preprocess_copyrights(self, cprocessor):
         """ Process raw copyrights to remove unnecessary text"""
+
         processed_copyrights = []
         for copyright_entry in self.copyrights:
 
-            logging.debug("raw copyright:" + copyright_entry['updatedCopyright'])
+            logging.debug("raw copyright: " + copyright_entry['updatedCopyright'])
             if not copyright_entry['active']:
                 continue
 
-            logging.debug("raw copyright:"+copyright_entry['updatedCopyright'])
-            # Remove copyright symbols and replace with "(C)"
-            copyright_text = copyright_entry['updatedCopyright'].replace("&copy", "(C)").replace("&#169;", "(C)")
-
-
-            # Convert any html to text
-            copyright_text = html2text.html2text(copyright_text)
-
-            # Remove any non unicode characters
-            copyright_text = self.remove_control_chars(copyright_text)
-
-            # Remove new lines
-            copyright_text = copyright_text.replace("\r\n", " ").replace("\n", " ")  # Remove all newlines
-            copyright_text = copyright_text.replace("\\n", " ") # Remove all "newlines"
-
-            # Remove comments delimiters
-            copyright_text = copyright_text.replace("-->", "").replace("<!--", "")  # XML
-            copyright_text = copyright_text.replace("// ", "").replace(" //", "").replace("/*", "").replace("*/",
-                                                                                                  "")  # Remove comments (C-like)
-            copyright_text = copyright_text.replace("#", "")  # Remove comments (Shell)
-            copyright_text = copyright_text.replace("rem ", "")  # Batch scripts?
-
-            # Remove < > and [ ] , typically used around mail and urls e.g. <fred@flintstones.com>
-            copyright_text = copyright_text.replace("<", "").replace(">", "")
-            copyright_text = copyright_text.replace("[", " ").replace("]", " ")
-
-            # Remove * and ~ , this often comes from comments where there is a box of asterisks like this:
-            # **************
-            # * box of text
-            # **************
-            copyright_text = copyright_text.replace("*"," ")
-            copyright_text = copyright_text.replace("~ ~","")
-
-            # Remove ============= , happens Often used to delineate text. i.e:
-            # ===================================
-            # copyright (C) 2020 Rob Haines
-            copyright_text = regex.sub("======.*", "", copyright_text, flags=regex.IGNORECASE)
-
-            # Clean up whitespace
-            copyright_text = copyright_text.strip()
-            copyright_text = regex.sub("\s+", " ", copyright_text)  # Reduce Multiple spaces to single spaces to improve merge
-
-
-            # Remove "all rights reserved". Need to check if this is OK? Possibly add it back again after merging?
-            copyright_text = regex.sub("All rights Reserved.*", "", copyright_text, flags=regex.IGNORECASE)
-
-
-            # Licence Cleanup - Where copyright is part of a license, e.g.
-            # copyright (C) 2020 Rob Haines. This library is free software ....
-            copyright_text = regex.sub("This library is free software.*", "", copyright_text,
-                                  flags=regex.IGNORECASE)
-            copyright_text = regex.sub("under the terms of.*", "", copyright_text, flags=regex.IGNORECASE)
-            copyright_text = regex.sub("Licensed under.*", "", copyright_text, flags=regex.IGNORECASE)
-            copyright_text = regex.sub("Released under.*", "", copyright_text, flags=regex.IGNORECASE)
-            copyright_text = regex.sub("Permission is hereby.*", "", copyright_text, flags=regex.IGNORECASE)
-            copyright_text = regex.sub("This product includes software.*", "", copyright_text,
-                                  flags=regex.IGNORECASE)  # Seems to be common in apache
-            copyright_text = regex.sub("The .* licenses this file.*", "", copyright_text,
-                                  flags=regex.IGNORECASE)  # Seems to be common in apache code
-            copyright_text = regex.sub("Verbatim copying and distribution.*", "", copyright_text,
-                                  flags=regex.IGNORECASE)
-            copyright_text = regex.sub("This (file )*is free software.*", "", copyright_text,
-                                  flags=regex.IGNORECASE)
-            copyright_text = regex.sub("This program is made available under.*", "", copyright_text,
-                                  flags=regex.IGNORECASE)
-
-            # Code cleanup, where copyrights are added to code, often there are keywords that can be used
-            # to show where the copyright ends and the code starts, happens often in minified java script
-            copyright_text = regex.sub("package \w.*", "", copyright_text)  # Remove where is copyright is part of java file
-            copyright_text = regex.sub("@(Deprecated|SuppressWarnings|version|param).*", "",
-                                  copyright_text)  # part of java file
-            # Javascript
-            copyright_text = regex.sub("(static|public|protected|private|class|interface).*", "",copyright_text)
-
-
-            # And finally....
-            copyright_text = regex.sub('[,.]\s?$', '', copyright_text)  # Punctuation? Where were going we don't need punctuation.
-            copyright_text = regex.sub('".*', '', copyright_text)
-            copyright_text = copyright_text.strip()
+            copyright_text = copyright_entry['updatedCopyright']
+            copyright_text = cprocessor.preprocess(copyright_text)
 
             logging.debug("processed copyright:" + copyright_text)
             copyright_entry["processed_copyright"] = copyright_text
 
 
     def filter_copyrights(self):
-        p = regex.compile(r'copyright[ ][^0-9]{0,20}[12][90][0-9]{2}|\(C\)[ ,\-:;\w]{5}|©[ ,\-:\w]{5}|@author', regex.IGNORECASE)
+        p = regex.compile(r'copyright[ :]{1,2}[^0-9]{0,20}[12][90][0-9]{2}|\(C\)\s[ ,\-:;\w]{5}|©\s[ ,\-:\w]{5}|@author', regex.IGNORECASE)
         matches = {}
         rejected_matches = []
         for copyright in self.copyrights:
@@ -276,7 +206,6 @@ class CopyrightManager:
     def print_range(self, date):
         output = []
         year_list = list(date.keys())
-        year_list.append(999999)
         year_list.sort()
         start_year = None
         last_year = None
@@ -299,14 +228,13 @@ class CopyrightManager:
         return ','.join(output)
 
 
-    def get_copyrights(self, showRejected=False, annotateResults=False, unfiltered = False):
+    def get_copyrights(self, cprocessor, showRejected=False, annotateResults=False, unfiltered = False):
 
         if not unfiltered:
         #Preprocess copyrights to remove noise
-            self.preprocess_copyrights()
-            filtered_copyrights,rejected_copyrights=self.filter_copyrights()
-
-            coalesced_copyrights,non_coalesced_copyrights = self.coalesce_dates(filtered_copyrights)
+            self.preprocess_copyrights(cprocessor)
+            filtered_copyrights, rejected_copyrights=self.filter_copyrights()
+            coalesced_copyrights, non_coalesced_copyrights = self.coalesce_dates(filtered_copyrights)
 
             output=coalesced_copyrights
             output.extend(non_coalesced_copyrights)

--- a/copyrightmanager.py
+++ b/copyrightmanager.py
@@ -1,3 +1,5 @@
+#!/
+
 from blackduck.HubRestApi import HubInstance
 import logging
 import regex

--- a/copyrightprocessor.py
+++ b/copyrightprocessor.py
@@ -1,0 +1,214 @@
+import regex
+import itertools
+import html2text
+
+
+class CopyrightProcessor:
+    """Process copyright to cleanup noise caused by licenses and unfiltered language parts"""
+    def __init__(self, languages, max_lines):
+        self.languages = languages
+        self.max_lines = max_lines
+        self.code_fragments = self.load_code_fragements()
+        self.license_fragments = self.load_license_fragments() 
+        
+
+    def load_code_fragements(self):
+        """Load code fragments sorted by language"""
+
+        code_dict = {}
+        code_dict['csharp'] = []
+        code_dict['csharp'].append("#(using|define|if|else|end|nullable).*")            # Remove C# preprocessor directives
+        code_dict['csharp'].append("(//|/\*|\*/|\*)")                                   # Remove comments
+
+        code_dict['cpp'] = []
+        code_dict['cpp'].append("#(include|define|if|else|end|pragma).*")               # Remove C/C++ preprocessor directives
+        code_dict['cpp'].append("(//|/\*|\*/|\*)")                                      # Remove comments
+
+        code_dict['java'] = []
+        code_dict['java'].append("@(Deprecated|SuppressWarnings|version|param).*")      # Remove Java attributions
+        code_dict['java'].append("package \w.*")                                        # Remove Java packages
+        code_dict['java'].append("(//|/\*|\*/|\*)")                                     # Remove comments
+
+
+        code_dict['js'] = []
+        code_dict['js'].append("(static|public|protected|private|class|interface).*")   # Remove JavaScript
+        code_dict['js'].append("(//|/\*|\*/|\*)")                                       # Remove comments
+
+        code_dict['xml'] = []
+        code_dict['xml'].append("<!--")                                                 # Remove XML comments
+        code_dict['xml'].append("-->")
+
+        code_dict['shell'] = []
+        code_dict['shell'].append("#")                                                  # Remove shell comments
+        code_dict['shell'].append("rem")
+        code_dict['shell'].append("<#")
+
+        code_dict['sql'] = []
+        code_dict['sql'].append("--")                                                  # Remove SQL comments
+        
+        filtered_code_fragments = []
+
+        # add unique all code fragments
+        if len(self.languages) == 0 or "all" in self.languages:
+           self.languages = list(code_dict.keys())
+        
+        # add unique code fragments sorted by languages
+        for language in self.languages:
+            if language in list(code_dict.keys()):
+                for centry in code_dict[language]:
+                    if centry not in filtered_code_fragments:
+                        filtered_code_fragments.append(centry)
+
+        return filtered_code_fragments
+
+    def load_license_fragments(self):
+        """Load license fragments to remove identified ones by remove_license_fragments"""
+       
+        license_fragments = []
+        license_fragments.append("Under the terms of.*")
+        license_fragments.append("(Licensed|Released) under.*")
+        license_fragments.append("Redistribution and.*")
+        license_fragments.append("Permission (is|to).*")
+        license_fragments.append("Everyone (is|must).*")
+        license_fragments.append("The.* licenses this file.*",) 
+        license_fragments.append("Verbatim copying and distribution.*")
+        license_fragments.append("This.* (is|file|script|library|program|product|license).*")
+
+        # Need to check if this is OK? Possibly add it back again after merging?
+        # license_fragments.append("All rights Reserved.*")
+
+        return license_fragments
+    
+    def contains_regex(self, text):
+        return True if "*" in text else False
+
+    def remove_code_fragments(self, copyright_text):
+        """Remove code fragments using loaded code fragments only"""
+        for code in self.code_fragments:
+            # TODO do proper test for regular expression
+            if self.contains_regex(code):
+                copyright_text = regex.sub(code, "", copyright_text)
+            else:
+                copyright_text = copyright_text.replace(code, "")
+
+        return copyright_text.strip()
+
+    def remove_license_fragments(self, copyright_text):
+        """Remove licenses, where copyright is part of a license and vice versa"""
+
+        for lf in self.license_fragments:
+            copyright_text = regex.sub(lf, "", copyright_text, flags=regex.IGNORECASE)
+
+        return copyright_text.strip()
+
+    def remove_copyright_lines(self, copyright_text):
+        """Remove copyright lines that are garbage, like a third line"""
+        
+        # Concat all lines before max_linex with "\n"
+        # Remove all lines after max_lines
+        copyright_text = copyright_text.replace("\\n", "\n").replace("\r\n", "\n")
+        copyright_text = copyright_text.replace("\t", "\n")
+        if (self.max_lines > 1):
+            copyright_text = copyright_text.replace("\n", " ", self.max_lines-1)
+        copyright_text = regex.sub("\n.*", "", copyright_text)
+
+        return copyright_text.strip()
+
+    def remove_separators_and_boxes(self, copyright_text):
+        """Remove separators and boxes, which are ofter used to separate or delineate copyrights entries"""
+
+        # Remove * and ~ , this often comes from comments where there is a box of asterisks like this:
+        # **************
+        # * box of text
+        # **************
+        copyright_text = copyright_text.replace("*","")
+        copyright_text = copyright_text.replace("~ ~","")
+        
+        # Remove ============= , happens Often used to delineate text. i.e:
+        # ===================================
+        # copyright (C) 2020 Rob Haines
+        copyright_text = regex.sub("======.*", "", copyright_text, flags=regex.IGNORECASE)
+        copyright_text = regex.sub("------.*", "", copyright_text, flags=regex.IGNORECASE)
+        
+        return copyright_text
+    
+    def remove_whitespaces(self, copyright_text):
+        """Reduce Multiple spaces to single spaces to improve merge"""
+        copyright_text = copyright_text.strip()
+        copyright_text = regex.sub("\s+", " ", copyright_text)  
+
+        return copyright_text
+
+    def remove_punctuations(self, copyright_text):
+        """Remove punctuations, improves ability to merge copyrights"""
+        copyright_text = regex.sub('[,.]\s?$', '', copyright_text)  
+        copyright_text = regex.sub('".*', '', copyright_text)
+
+        return copyright_text
+
+    def remove_tags(self, copyright_text):
+        """Remove tags by converting into text only"""
+        copyright_text = html2text.html2text(copyright_text)
+
+        return copyright_text
+
+    def remove_brackets(self, copyright_text):
+        """Remove < > and [ ] , typically used around mail and urls e.g. <fred@flintstones.com>"""
+        copyright_text = copyright_text.replace("<", "").replace(">", "")
+        copyright_text = copyright_text.replace("[", "").replace("]", "")
+        copyright_text = copyright_text.replace("{", "").replace("}", "")
+        copyright_text = copyright_text.replace("(", "").replace(")", "")
+
+        return copyright_text.strip()
+
+    def remove_control_chars(self, s):
+
+        control_chars = ''.join(map(chr, itertools.chain(range(0x00, 0x20), range(0x7f, 0xa0))))
+        control_char_regex = regex.compile('[%s]' % regex.escape(control_chars))
+
+        return control_char_regex.sub(' ', s)
+
+    def update_copyright_sign(self, s):
+        """Replace copyright sign by (C)"""
+        return s.replace("&copy", "(C)").replace("&#169;", "(C)")
+  
+    def preprocess(self, copyright_text):
+        """ Process raw copyrights to remove unnecessary text"""
+        input = copyright_text
+
+        # Remove copyright lines that are garbage, like e.g. a third line"
+        copyright_text = self.remove_copyright_lines(copyright_text)
+
+        # Remove tags using html2text
+        # copyright_text = self.remove_tags(copyright_text)        
+
+        # Remove code fragments from different languages
+        copyright_text = self.remove_code_fragments(copyright_text)
+
+        # Remove licenses, where copyright contains license and vice versa
+        copyright_text = self.remove_license_fragments(copyright_text)
+                              
+        # Remove brackets typically used around mail and urls
+        # copyright_text = self.remove_brackets(copyright_text)
+
+        # Remove all punctuations that are not required 
+        # copyright_text = self.remove_punctuations(copyright_text)
+
+        # Remove multiples of whitespaces 
+        copyright_text = self.remove_whitespaces(copyright_text)
+
+         # Remove separators and boxes
+        copyright_text = self.remove_separators_and_boxes(copyright_text)
+
+        # Remove any non unicode characters
+        copyright_text = self.remove_control_chars(copyright_text)
+
+        # Remove copyright symbols and replace with "(C)"
+        copyright_text = self.update_copyright_sign(copyright_text)
+        
+        return copyright_text
+
+    
+
+
+    

--- a/reportmanager.py
+++ b/reportmanager.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+
+import sys
+import mmap
+import regex
+import shutil
+import logging
+import argparse
+from copyrightprocessor import CopyrightProcessor
+
+class ReportManager:
+
+    __merge_file = ""
+    __split_file = ""
+
+    __split_dict = {}
+    #__split_files = ["component.part", "copyright.part", "license.part"]
+    #__split_strings = ["Components: ", "Copyrights: ", "Licenses: "]
+
+    def __init__(self, split_file, merge_file):
+        self.__split_file = split_file
+        self.__merge_file = merge_file
+
+        self.__split_dict["component"] = { "filename":"component.part", "separator":"Components: "}
+        self.__split_dict["copyright"] = { "filename":"copyright.part", "separator":"Copyright Text: "} 
+        self.__split_dict["license"]   = { "filename":"license.part", "separator":"Licenses: "} 
+
+
+    def write_file(self, filename, lines):
+        with open(filename, "w") as f: 
+            for line in lines:
+                f.write(line)
+        logging.debug("File " + filename + ", written lines " + str(len(lines)))
+
+    def split_file(self):
+
+        with open(self.__split_file, 'r') as f:
+            lines = f.readlines()
+            
+        n = 0
+        ncopy = 0
+        nlicense = 0
+        for line in lines:
+            if ncopy == 0 and line.find(self.__split_dict["copyright"]["separator"]) != -1:
+                ncopy = n
+            elif nlicense == 0 and line.find(self.__split_dict["license"]["separator"]) != -1:
+                nlicense = n
+            elif ncopy != 0 and nlicense != 0:
+                break
+            n += 1
+        
+        logging.debug("Report file lines " + str(len(lines)))
+        logging.debug("ncopy = " + str(ncopy))
+        logging.debug("nlicense = " + str(nlicense))
+        
+        self.write_file(self.__split_dict["component"]["filename"], lines[:ncopy])
+        self.write_file(self.__split_dict["copyright"]["filename"], lines[ncopy:nlicense])
+        self.write_file(self.__split_dict["license"]["filename"], lines[nlicense:])
+        
+        return self.__split_dict
+    
+    def merge_files(self):
+
+        filenames = []
+        filenames.append(self.__split_dict["component"]["filename"])
+        filenames.append(self.__split_dict["copyright"]["filename"])
+        filenames.append(self.__split_dict["license"]["filename"])
+
+        with open(self.__merge_file, 'w') as outfile:
+            for fname in filenames:
+                with open(fname) as infile:
+                    for line in infile:
+                        outfile.write(line)
+
+        return self.__merge_file
+    
+    def load_components(self):
+        with open(self.__split_dict["component"]["filename"], 'r') as infile:
+             lines = infile.readlines()
+
+        component_list = []     
+        ncomp_found = False
+        for line in lines:
+            if ncomp_found == False:
+                if line.find(self.__split_dict["component"]["separator"]) != -1:
+                    ncomp_found = True
+            else:
+                data = line.split(": ")
+                if not data[0].isspace():
+                    component_list.append(data[0].strip())
+    
+        return component_list
+
+    def load_copyrights(self):
+        logging.debug("Load copyrights")
+        copyright_dict = {}
+        skip = True
+        component = ""
+
+        with open(self.__split_dict["copyright"]["filename"], 'r') as infile:
+            lines = infile.readlines()       
+
+        for line in lines:
+            # skip 
+            if not line: 
+                continue
+            elif skip:
+                if line.startswith(self.__split_dict["copyright"]["separator"]):
+                    skip = False
+            # component found
+            elif line[0].isalpha():
+                component = line.strip()
+                copyright_dict[component]=[]
+                #logging.debug("Found component " + component )
+            # copyright found
+            elif line[0].startswith("\t"):
+                copyright = line.strip()
+                copyright_dict[component].append(copyright)
+                #logging.debug("Add copyright " + copyright)
+                
+        return copyright_dict
+    
+    def clean_copyrights(self, copyrights):
+        logging.debug("Clean copyrights")
+        cleaned_dict = {}
+        garbage_dict = {}
+
+        processor = CopyrightProcessor("all", 1)
+        for component, copyright_list in copyrights.items():
+            cleaned_dict[component] = []
+            garbage_dict[component] = []
+            for copyright in copyright_list:
+                preprocessed = processor.preprocess(copyright)
+                postprocessed, garbage = processor.postprocess(preprocessed)
+                if len(postprocessed):
+                    # logging.debug(postprocessed)
+                    cleaned_dict[component].append(postprocessed)
+                elif len(garbage):
+                    logging.info("GARBAGE IN  " + copyright)
+                    logging.info("GARBAGE OUT " + garbage)
+                    garbage_dict[component].append(copyright)
+
+        return cleaned_dict
+    
+    def save_copyrights(self, copyrights):
+        header = self.__split_dict["copyright"]["separator"]
+        filename = self.__split_dict["copyright"]["filename"]
+        shutil.copy2(filename, filename + ".bak")
+
+        with open(filename, 'w') as outfile:
+            outfile.write(header + "\n\n")
+            for component, copyright_list in copyrights.items():
+                logging.debug(component)
+                outfile.write(component + "\n")
+                for copyright in copyright_list:
+                    outfile.write("\t" + copyright + "\n")
+        
+        return filename
+    
+## test code ##
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser("Report manager to split and merge files")
+    parser.add_argument("report_file",help="The report file name")
+    parser.add_argument("-s","--split", action="store_true", help="Split files")
+    parser.add_argument("-m","--merge", action="store_true", help="Merge files")
+    parser.add_argument("-d","--debug", action="store_true", help="Enable debug output")
+    parser.add_argument("-l","--list-components", action="store_true", help="List components require")
+    parser.add_argument("-c","--clean", action="store_true", help="Clean copyrights require --split")
+    args = parser.parse_args()
+
+    logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', stream=sys.stderr, level=logging.DEBUG)
+    logging.getLogger().setLevel(logging.INFO)
+    if args.debug:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+  
+
+    
+    manager = ReportManager(args.report_file, args.report_file)
+    
+    if (args.split):
+        result = manager.split_file()
+        print("Split files: " + str(result))
+
+    if args.merge:
+        result = manager.merge_files()
+        print("Merged files: " + str(result))
+
+    if (args.list_components):
+        _ = manager.split_file()
+        component_list = manager.load_components()
+        print("Component list: " + str(component_list))
+
+    if (args.clean):
+        _ = manager.split_file()
+        
+        component_list = manager.load_components()
+        copyright_dict = manager.load_copyrights()
+        if len(component_list) != len(copyright_dict):
+            print("Mismach length component_list {} != copyfight_dict {}"
+                         .format(len(component_list),len(copyright_dict)))
+            print("Component list: " + str(component_list))
+            
+        copyright_dict = manager.clean_copyrights(copyright_dict)
+        filename = manager.save_copyrights(copyright_dict)
+        print("Copyright list: " + str(filename))
+
+        report = manager.merge_files()
+        print("Cleaned report: " + str(report))


### PR DESCRIPTION
Improve copyright loading with paging to fix the limitation to load
1000 copyrights per components only. The paging mechanism uses a
the API parameters "?limit=1000&offset=0" by default and extends the
loaded copyrights as long as the response is not empty.

Simplify copyright preprocessing by removing unnecessary steps and
sorting the them for better results. The steps to eliminate
punctuation, brackets and HTML have been deleted, because
copyright information MUST not be changed significantly. A new step
has been added to limit the amount of copyright lines to preprocess.
The rational behind this improvement is that copyright statements
are mostly represented with one or two lines only. The steps to
remove code and license fragments have been simplified by shorter
regular expressions to get better and faster results. Although this
steps are fast, further improvement permit to configure by language
which code fragments should be removed. Currently hardcoded patterns
include "csharp,cpp,java,js,xml,shell,sql" which where derived from
CopyrightManager preprocessing steps.

All preprocessing steps has been moved to CopyrightProcessor class.